### PR TITLE
cmake: generate instructions for ARM processors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,14 @@ OPTION(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 OPTION(BUILD_PYTHON "Build Python extension" OFF)
 OPTION(BUILD_POSITION_INDEPENDENT_CODE "Build position independent code (-fPIC)" ON)
 
-add_definitions (-Wall -march=native -O3) #TODO use correct c++11 def once everybody has moved to gcc 4.7 # for now I even removed std=gnu++0x
+IF (CMAKE_SYSTEM_PROCESSOR MATCHES "(arm64)|(ARM64)|(aarch64)|(AARCH64)")
+  add_definitions (-Wall -march=armv8-a -O3)
+ELSEIF (CMAKE_SYSTEM_PROCESSOR MATCHES 
+        "(arm)|(ARM)|(armhf)|(ARMHF)|(armel)|(ARMEL)")
+  add_definitions (-Wall -march=armv7-a -O3)
+ELSE ()
+  add_definitions (-Wall -march=native -O3) #TODO use correct c++11 def once everybody has moved to gcc 4.7 # for now I even removed std=gnu++0x
+ENDIF()
 
 IF(BUILD_POSITION_INDEPENDENT_CODE)
   add_definitions( -fPIC )


### PR DESCRIPTION
-march=native assumes an x86 based cpu, add logic to select
proper instruction set for ARM processors.

For reference: OpenDroneMap/OpenDroneMap/issues/484

Signed-off-by: Tyler Baker <tyler.baker@linaro.org>